### PR TITLE
Fix read screen pixels

### DIFF
--- a/src/rayfork-gfx-backend-opengl.c
+++ b/src/rayfork-gfx-backend-opengl.c
@@ -2875,7 +2875,7 @@ RF_API void rf_gfx_read_screen_pixels(rf_color* dst, int width, int height)
             int j = (y * width) + x;
 
             // only flip screen pixels once
-            if (i > height / 2)
+            if (y > height / 2)
             {
                 rf_color temp = dst[i];
                 dst[i] = dst[j];

--- a/src/rayfork-gfx-backend-opengl.c
+++ b/src/rayfork-gfx-backend-opengl.c
@@ -2871,11 +2871,20 @@ RF_API void rf_gfx_read_screen_pixels(rf_color* dst, int width, int height)
     {
         for (rf_int x = 0; x < width; x++)
         {
-            dst[((height - 1) - y) * width + x] = dst[(y * width) + x]; // Flip line
+            int i = ((height - 1) - y) * width + x;
+            int j = (y * width) + x;
+
+            // only flip screen pixels once
+            if (i > height / 2)
+            {
+                rf_color temp = dst[i];
+                dst[i] = dst[j];
+                dst[j] = temp;  
+            }
 
             // Set alpha component value to 255 (no trasparent image retrieval)
             // NOTE: Alpha value has already been applied to RGB in framebuffer, we don't need it!
-            if (((x + 1) % 4) == 0) dst[((height - 1) - y) * width + x].a = 255;
+            if(dst[j].a == 0) dst[j].a = 255;
         }
     }
 }


### PR DESCRIPTION
## Summary

The original algorithm for reading screen pixels had the problem of not storing the previously screen pixel, so when the screen was flipped half of the pixels were replaced with a mirror version.
It also had the problem of flipping pixels twice, as it when from 0 to height, instead of from 0 to half of the height.